### PR TITLE
Remove app running instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,26 +54,6 @@
 
 ---
 
-##  Running the App
-
-## Backend (Python)
-
-cd backend/
-
-pip install -r requirements.txt
-
-python app.py
-
-## Frontend (Flutter)
-
-cd ../frontend/
-
-flutter pub get
-
-flutter run
-
-
-
 ---
 
 ##  Contributors


### PR DESCRIPTION
Removed instructions for running the app in both backend and frontend sections.